### PR TITLE
Fix for some websocket servers replying with a diffrent websockets 101 message

### DIFF
--- a/lua/autorun/server/websocket.lua
+++ b/lua/autorun/server/websocket.lua
@@ -1059,7 +1059,7 @@ function WS.verifyhandshake(message,isServer)
 			return false
 		end
 	else
-		if(first_line!="HTTP/1.1 101 Switching Protocols") then
+		if(first_line!="HTTP/1.1 101 Switching Protocols" and first_line!="HTTP/1.1 101 Web Socket Protocol Handshake") then
 			WS.Error("Server not sending proper response code")
 			return false
 		end


### PR DESCRIPTION
echo.websocket.org does this as an example
